### PR TITLE
[FEAT] KKUMI-74 KKUMI-75 #65 : 포스트 작성 > 본문 내용 작성(1MD) + 카테고리 선택(1MD)

### DIFF
--- a/feature/home/src/main/java/com/swmarastro/mykkumi/feature/home/HomeFragment.kt
+++ b/feature/home/src/main/java/com/swmarastro/mykkumi/feature/home/HomeFragment.kt
@@ -29,7 +29,7 @@ import java.util.TimerTask
 
 @AndroidEntryPoint
 class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
-    private val viewModel by viewModels<HomeViewModel>({ requireActivity() })
+    private val viewModel by viewModels<HomeViewModel>()
 
     private lateinit var bannerAdapter: HomeBannerViewPagerAdapter
     private lateinit var postListAdapter: PostListAdapter

--- a/feature/home/src/main/java/com/swmarastro/mykkumi/feature/home/banner/HomeBannerAllFragment.kt
+++ b/feature/home/src/main/java/com/swmarastro/mykkumi/feature/home/banner/HomeBannerAllFragment.kt
@@ -15,7 +15,7 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class HomeBannerAllFragment : BaseFragment<FragmentHomeBannerAllBinding>(R.layout.fragment_home_banner_all) {
 
-    private val viewModel by viewModels<HomeBannerAllViewModel>({ requireActivity() })
+    private val viewModel by viewModels<HomeBannerAllViewModel>()
     private lateinit var bannerAllAdapter: HomeBannerAllAdapter
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/feature/home/src/main/java/com/swmarastro/mykkumi/feature/home/banner/HomeBannerDetailFragment.kt
+++ b/feature/home/src/main/java/com/swmarastro/mykkumi/feature/home/banner/HomeBannerDetailFragment.kt
@@ -12,7 +12,7 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class HomeBannerDetailFragment : BaseFragment<FragmentHomeBannerDetailBinding>(R.layout.fragment_home_banner_detail) {
 
-    private val viewModel by viewModels<HomeBannerDetailViewModel>({ requireActivity() })
+    private val viewModel by viewModels<HomeBannerDetailViewModel>()
     private val args: HomeBannerDetailFragmentArgs by navArgs()
 
     override suspend fun initView() {

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditFragment.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditFragment.kt
@@ -103,23 +103,22 @@ class PostEditFragment : BaseFragment<FragmentPostEditBinding>(R.layout.fragment
 
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 if (!s.isNullOrEmpty()){
-                    Log.d("test", "onTextChanged - start: ${start}, before: ${before}, count: ${count}")
                     // 본문 글자수
                     if(s.length > MAX_POST_CONTENT_LENGTH) {
-                        if(before == 0) binding.edittextInputContent.setText(concat(s.subSequence(0, start), s.subSequence(start + count, s.length)))
-                        else binding.edittextInputContent.setText(concat(s.subSequence(0, before), s.subSequence(count, s.length)))
+                        val subLength = count - (s.length - MAX_POST_CONTENT_LENGTH) // 삭제하고 남겨야 할 길이
+                        binding.edittextInputContent.setText(concat(s.subSequence(0, start + subLength), s.subSequence(start + count, s.length)))
 
-                        binding.edittextInputContent.setSelection(max(start, before)) // 커서를 입력하고 있던 곳에
+                        binding.edittextInputContent.setSelection(start + subLength) // 커서를 입력하고 있던 곳에
                         showToast(getString(R.string.notice_post_content_max_length))
                     }
 
                     // 해시태그 개수
                     if(s.count { it == '#' } > MAX_POST_CONTENT_HASHTAG_COUNT) {
                         // 20개 넘어가는 건 자르기 = 방금 입력된 문자
-                        if(before == 0) binding.edittextInputContent.setText(concat(s.subSequence(0, start), s.subSequence(start + count, s.length)))
-                        else binding.edittextInputContent.setText(concat(s.subSequence(0, before), s.subSequence(count, s.length)))
+                        val hashTagIndex = s.indexOf('#', start)
+                        binding.edittextInputContent.setText(concat(s.subSequence(0, hashTagIndex), s.subSequence(start + count, s.length)))
 
-                        binding.edittextInputContent.setSelection(max(start, before)) // 커서를 입력하고 있던 곳에
+                        binding.edittextInputContent.setSelection(hashTagIndex) // 커서를 입력하고 있던 곳에
                         showToast(getString(R.string.notice_post_hashtag_max_count))
                     }
                 }

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditFragment.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditFragment.kt
@@ -18,15 +18,18 @@ import androidx.viewpager2.widget.ViewPager2
 import com.swmarastro.mykkumi.common_ui.base.BaseFragment
 import com.swmarastro.mykkumi.feature.post.confirm.PostConfirmBottomSheet
 import com.swmarastro.mykkumi.feature.post.databinding.FragmentPostEditBinding
-import com.swmarastro.mykkumi.feature.post.image.ImagePickerArgument
+import com.swmarastro.mykkumi.feature.post.hobbyCategory.SelectHobbyOfPostBottomSheet
+import com.swmarastro.mykkumi.feature.post.imagePicker.ImagePickerArgument
 import com.swmarastro.mykkumi.feature.post.imageWithPin.EditImageWithPinAdapter
 import com.swmarastro.mykkumi.feature.post.imageWithPin.InputProductInfoBottomSheet
 import com.swmarastro.mykkumi.feature.post.touchEvent.PostEditImageTouchCallback
-import kotlin.math.max
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class PostEditFragment : BaseFragment<FragmentPostEditBinding>(R.layout.fragment_post_edit),
     PostConfirmBottomSheet.PostConfirmListener,
-    InputProductInfoBottomSheet.InputProductInfoListener {
+    InputProductInfoBottomSheet.InputProductInfoListener,
+    SelectHobbyOfPostBottomSheet.SelectHobbyOfPostListener {
     private val viewModel by viewModels<PostEditViewModel>()
 
     private final val MAX_POST_CONTENT_LENGTH = 10      // 본문 글자 수
@@ -129,6 +132,16 @@ class PostEditFragment : BaseFragment<FragmentPostEditBinding>(R.layout.fragment
         binding.btnBack.setOnClickListener {
             navController?.popBackStack()
         }
+
+        // 포스트 등록 버튼
+        binding.textUploadPost.setOnClickListener(View.OnClickListener {
+            viewModel.doneEditPost(
+                this,
+                showToast = {
+                    showToast(it)
+                }
+            )
+        })
     }
 
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
@@ -305,13 +318,22 @@ class PostEditFragment : BaseFragment<FragmentPostEditBinding>(R.layout.fragment
     }
 
     // pin 이동 중일 때는 viewPager 전환 안 되게 막기
+    // 수직 스크롤도 막기
     private fun lockViewPagerMoving() {
         binding.viewpagerPostEditImages.isUserInputEnabled = false
+        binding.scrollEditPost.isEnabled = false
     }
 
     // pin 이동 끝나면 viewPager 전환 가능하게 풀어주기
+    // 수직 스크롤도 풀어주기
     private fun unlockViewPagerMoving() {
         binding.viewpagerPostEditImages.isUserInputEnabled = true
+        binding.scrollEditPost.isEnabled = true
+    }
+
+    // 카테고리 선택 완료 -> 포스트 작성
+    override fun doneSelectHobby(categoryId: Long) {
+        Toast.makeText(context, "포스트 등록: ${categoryId}", Toast.LENGTH_SHORT).show()
     }
 
     private fun showToast(message: String) {

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditViewModel.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditViewModel.kt
@@ -12,6 +12,7 @@ import androidx.navigation.NavController
 import com.swmarastro.mykkumi.domain.entity.PostEditPinProductVO
 import com.swmarastro.mykkumi.domain.entity.PostEditPinVO
 import com.swmarastro.mykkumi.feature.post.confirm.PostConfirmBottomSheet
+import com.swmarastro.mykkumi.feature.post.hobbyCategory.SelectHobbyOfPostBottomSheet
 import com.swmarastro.mykkumi.feature.post.imageWithPin.InputProductInfoBottomSheet
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -171,5 +172,25 @@ class PostEditViewModel  @Inject constructor(
     // 이미지 삭제 취소
     fun doneDeleteImage() {
         _isDeleteImageState.value = false
+    }
+
+    // 포스트 등록 시도
+    fun doneEditPost(
+        fragment: PostEditFragment,
+        showToast: (message: String) -> Unit
+    ) {
+        // 이미지가 하나 이상인지 확인
+        if (!postEditUiState.value.isNullOrEmpty()) {
+            selectHobbyCategory(fragment)
+        }
+        else {
+            showToast("포스트를 등록하려면 하나 이상의 이미지가 필요합니다.")
+        }
+    }
+
+    // 카테고리 선택 BottomSheet
+    fun selectHobbyCategory(fragment: PostEditFragment) {
+        val bottomSheet = SelectHobbyOfPostBottomSheet().apply { setListener(fragment) }
+        bottomSheet.show(fragment.parentFragmentManager, bottomSheet.tag)
     }
 }

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditViewModel.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditViewModel.kt
@@ -2,6 +2,8 @@ package com.swmarastro.mykkumi.feature.post
 
 import android.net.Uri
 import android.os.Bundle
+import android.text.TextUtils.concat
+import android.util.Log
 import androidx.core.net.toUri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -15,6 +17,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
+import kotlin.math.max
 
 @HiltViewModel
 class PostEditViewModel  @Inject constructor(

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/hobbyCategory/HobbyCategoryAdapter.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/hobbyCategory/HobbyCategoryAdapter.kt
@@ -1,0 +1,57 @@
+package com.swmarastro.mykkumi.feature.post.hobbyCategory
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.swmarastro.mykkumi.domain.entity.HobbyCategoryItemVO
+import com.swmarastro.mykkumi.feature.post.databinding.ItemHobbyCategoryBinding
+
+class HobbyCategoryAdapter (
+    private val hobbyCategorySpan: Int,
+    private val viewModel: SelectHobbyOfPostViewModel,
+) : RecyclerView.Adapter<HobbyCategoryAdapter.HobbyCategoryViewHolder>(){
+    var hobbyCategoryList = mutableListOf<HobbyCategoryItemVO>()
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): HobbyCategoryAdapter.HobbyCategoryViewHolder {
+        val binding = ItemHobbyCategoryBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return HobbyCategoryViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(
+        holder: HobbyCategoryAdapter.HobbyCategoryViewHolder,
+        position: Int
+    ) {
+        holder.bind(hobbyCategoryList[position])
+    }
+
+    override fun getItemCount(): Int = hobbyCategoryList.size
+
+    inner class HobbyCategoryViewHolder(
+        private val binding: ItemHobbyCategoryBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+        private lateinit var hobbySubCategoryAdapter: HobbySubCategoryAdapter
+
+        fun bind(item: HobbyCategoryItemVO) {
+            binding.textHobbyCategory.text = item.categoryName
+
+            hobbySubCategoryAdapter = HobbySubCategoryAdapter(
+                viewModel,
+                updateAllCategory = {
+                    notifyDataSetChanged()
+                }
+            )
+            hobbySubCategoryAdapter.hobbySubCategoryList = item.subCategories.toMutableList()
+            binding.recyclerviewHobbySubCategory.apply {
+                layoutManager = GridLayoutManager(
+                    context,
+                    hobbyCategorySpan
+                )
+                adapter = hobbySubCategoryAdapter
+            }
+        }
+    }
+}

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/hobbyCategory/HobbySubCategoryAdapter.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/hobbyCategory/HobbySubCategoryAdapter.kt
@@ -1,0 +1,53 @@
+package com.swmarastro.mykkumi.feature.post.hobbyCategory
+
+import android.graphics.Color
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.swmarastro.mykkumi.domain.entity.HobbySubCategoryItemVO
+import com.swmarastro.mykkumi.feature.post.databinding.ItemHobbySubCategoryBinding
+
+class HobbySubCategoryAdapter (
+    private val viewModel: SelectHobbyOfPostViewModel,
+    private val updateAllCategory: () -> Unit
+) : RecyclerView.Adapter<HobbySubCategoryAdapter.HobbySubCategoryViewHolder>(){
+    var hobbySubCategoryList = mutableListOf<HobbySubCategoryItemVO>()
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): HobbySubCategoryAdapter.HobbySubCategoryViewHolder {
+        val binding = ItemHobbySubCategoryBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return HobbySubCategoryViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(
+        holder: HobbySubCategoryAdapter.HobbySubCategoryViewHolder,
+        position: Int
+    ) {
+        holder.bind(hobbySubCategoryList[position])
+    }
+
+    override fun getItemCount(): Int = hobbySubCategoryList.size
+
+    inner class HobbySubCategoryViewHolder(
+        private val binding: ItemHobbySubCategoryBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: HobbySubCategoryItemVO) {
+            binding.textHobbySubCategory.text = item.subCategoryName
+
+            if(item.subCategoryId == viewModel.selectedHobby.value) {
+                binding.linearSubHobbyCategory.setBackgroundColor(Color.GREEN)
+            }
+            else {
+                binding.linearSubHobbyCategory.background = null
+            }
+
+            binding.linearSubHobbyCategory.setOnClickListener(View.OnClickListener {
+                viewModel.setHobbySelected(item.subCategoryId)
+                updateAllCategory()
+            })
+        }
+    }
+}

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/hobbyCategory/SelectHobbyOfPostBottomSheet.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/hobbyCategory/SelectHobbyOfPostBottomSheet.kt
@@ -1,0 +1,84 @@
+package com.swmarastro.mykkumi.feature.post.hobbyCategory
+
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Observer
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.swmarastro.mykkumi.common_ui.base.BaseBottomSheetFragment
+import com.swmarastro.mykkumi.feature.post.R
+import com.swmarastro.mykkumi.feature.post.databinding.FragmentSelectHobbyOfPostBottomSheetBinding
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class SelectHobbyOfPostBottomSheet : BaseBottomSheetFragment<FragmentSelectHobbyOfPostBottomSheetBinding>(R.layout.fragment_select_hobby_of_post_bottom_sheet) {
+    private val viewModel by viewModels<SelectHobbyOfPostViewModel>()
+
+    private var selectHobbyOfPostListener: SelectHobbyOfPostListener? = null
+
+    private lateinit var hobbyCategoryAdapter: HobbyCategoryAdapter
+    private var hobbyCategorySpan: Int = 1
+
+    interface SelectHobbyOfPostListener {
+        fun doneSelectHobby(categoryId: Long)
+    }
+
+    fun setListener(selectHobbyOfPostListener: SelectHobbyOfPostListener) {
+        this.selectHobbyOfPostListener = selectHobbyOfPostListener
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        viewModel.hobbyCategoryUiState.observe(viewLifecycleOwner, Observer {
+            hobbyCategoryAdapter.hobbyCategoryList = it
+            hobbyCategoryAdapter.notifyDataSetChanged()
+        })
+
+        // 선택 완료
+        binding.btnDoneSelectHobbyCategory.setOnClickListener {
+            if (viewModel.selectedHobby.value == -1L)
+                Toast.makeText(context, "select_hobby_category_of_post", Toast.LENGTH_SHORT).show()
+
+            else {
+                viewModel.selectedHobby.value?.let {
+                    selectHobbyOfPostListener?.doneSelectHobby(
+                        it
+                    )
+                }
+                dismiss()
+            }
+        }
+    }
+
+    override suspend fun initView() {
+        bind {
+            vm = viewModel
+        }
+
+        initRecyclerView()
+        viewModel.getHobbyCategoryList()
+    }
+
+    private fun initRecyclerView() {
+        val screenWidth = resources.displayMetrics.widthPixels
+        val itemWidth = resources.getDimensionPixelSize(R.dimen.item_hobby_sub_category)
+
+        hobbyCategorySpan = screenWidth / itemWidth
+
+        hobbyCategoryAdapter = HobbyCategoryAdapter(
+            hobbyCategorySpan,
+            viewModel
+        )
+        binding.recyclerviewHobbyCategory.apply {
+            layoutManager = LinearLayoutManager(
+                context,
+                LinearLayoutManager.VERTICAL,
+                false
+            )
+            adapter = hobbyCategoryAdapter
+            isNestedScrollingEnabled = false
+        }
+    }
+}

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/hobbyCategory/SelectHobbyOfPostViewModel.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/hobbyCategory/SelectHobbyOfPostViewModel.kt
@@ -1,0 +1,46 @@
+package com.swmarastro.mykkumi.feature.post.hobbyCategory
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.swmarastro.mykkumi.domain.entity.HobbyCategoryItemVO
+import com.swmarastro.mykkumi.domain.entity.HobbySubCategoryItemVO
+import com.swmarastro.mykkumi.domain.usecase.post.GetHobbyCategoryListUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.lang.Exception
+import javax.inject.Inject
+
+@HiltViewModel
+class SelectHobbyOfPostViewModel @Inject constructor(
+    private val getHobbyCategoryListUseCase: GetHobbyCategoryListUseCase,
+) : ViewModel() {
+    private val _hobbyCategoryUiState = MutableLiveData<MutableList<HobbyCategoryItemVO>>(mutableListOf())
+    val hobbyCategoryUiState: LiveData<MutableList<HobbyCategoryItemVO>> get() = _hobbyCategoryUiState
+
+    private val _selectedHobby = MutableLiveData<Long>(-1L)
+    val selectedHobby: LiveData<Long> get() = _selectedHobby
+
+    // 관심 취미 데이터 세팅
+    fun getHobbyCategoryList() {
+        viewModelScope.launch {
+            try {
+                val hobbyCategories = withContext(Dispatchers.IO) {
+                    getHobbyCategoryListUseCase()
+                }
+                _hobbyCategoryUiState.value?.clear()
+                _hobbyCategoryUiState.value = hobbyCategories.categories.toMutableList()
+            } catch (e: Exception) {
+                _hobbyCategoryUiState.value?.clear()
+            }
+        }
+    }
+
+    // 관심 취미 선택
+    fun setHobbySelected(selectHobbyId: Long) {
+        _selectedHobby.value = selectHobbyId
+    }
+}

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/imagePicker/ImagePickerAdapter.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/imagePicker/ImagePickerAdapter.kt
@@ -1,4 +1,4 @@
-package com.swmarastro.mykkumi.feature.post.image
+package com.swmarastro.mykkumi.feature.post.imagePicker
 
 import android.content.Context
 import android.view.LayoutInflater

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/imagePicker/ImagePickerData.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/imagePicker/ImagePickerData.kt
@@ -1,4 +1,4 @@
-package com.swmarastro.mykkumi.feature.post.image
+package com.swmarastro.mykkumi.feature.post.imagePicker
 
 import android.net.Uri
 import android.os.Parcelable

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/imagePicker/ImagePickerFragment.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/imagePicker/ImagePickerFragment.kt
@@ -1,11 +1,7 @@
-package com.swmarastro.mykkumi.feature.post.image
+package com.swmarastro.mykkumi.feature.post.imagePicker
 
 import android.app.Activity
-import android.content.Intent
-import android.content.pm.PackageManager
-import android.net.Uri
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
@@ -16,7 +12,6 @@ import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.GridLayoutManager
 import com.swmarastro.mykkumi.common_ui.base.BaseFragment
 import com.swmarastro.mykkumi.common_ui.permission.ImagePermissionUtils
-import com.swmarastro.mykkumi.feature.post.PostEditFragmentArgs
 import com.swmarastro.mykkumi.feature.post.R
 import com.swmarastro.mykkumi.feature.post.databinding.FragmentImagePickerBinding
 

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/imagePicker/ImagePickerViewModel.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/imagePicker/ImagePickerViewModel.kt
@@ -1,12 +1,10 @@
-package com.swmarastro.mykkumi.feature.post.image
+package com.swmarastro.mykkumi.feature.post.imagePicker
 
 import android.annotation.SuppressLint
 import android.content.Context
 import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
-import android.util.Log
-import androidx.core.net.toUri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/imageWithPin/InputProductInfoBottomSheet.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/imageWithPin/InputProductInfoBottomSheet.kt
@@ -2,6 +2,7 @@ package com.swmarastro.mykkumi.feature.post.imageWithPin
 
 import android.os.Bundle
 import android.text.Editable
+import android.text.TextUtils.concat
 import android.text.TextWatcher
 import android.util.Log
 import android.view.View
@@ -9,11 +10,12 @@ import android.widget.Toast
 import com.swmarastro.mykkumi.common_ui.base.BaseBottomSheetFragment
 import com.swmarastro.mykkumi.feature.post.R
 import com.swmarastro.mykkumi.feature.post.databinding.FragmentInputProductInfoBottomSheetBinding
+import kotlin.math.max
 
 
 class InputProductInfoBottomSheet : BaseBottomSheetFragment<FragmentInputProductInfoBottomSheetBinding>(R.layout.fragment_input_product_info_bottom_sheet) {
 
-    final val MAX_PRODUCT_NAME_LENGTH = 20
+    private final val MAX_PRODUCT_NAME_LENGTH = 20
 
     private var inputProductInfoListener: InputProductInfoListener? = null
     private var position: Int? = null
@@ -35,17 +37,18 @@ class InputProductInfoBottomSheet : BaseBottomSheetFragment<FragmentInputProduct
         // 제품명 글자 수 제한
         binding.edittextInputProductName.addTextChangedListener(object: TextWatcher {
             override fun afterTextChanged(s: Editable?) {
-
             }
 
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
-
             }
 
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 if(!s.isNullOrEmpty() && s.length > MAX_PRODUCT_NAME_LENGTH) {
-                    binding.edittextInputProductName.setText(s.subSequence(0, MAX_PRODUCT_NAME_LENGTH)) // 20자 넘어가는 건 자르기
-                    binding.edittextInputProductName.setSelection(MAX_PRODUCT_NAME_LENGTH) // 커서를 맨 뒤로
+                    // 20자 넘어가는 건 자르기 = 방금 입력된 문자
+                    if(before == 0) binding.edittextInputProductName.setText(concat(s.subSequence(0, start), s.subSequence(start + count, s.length)))
+                    else binding.edittextInputProductName.setText(concat(s.subSequence(0, before), s.subSequence(count, s.length)))
+
+                    binding.edittextInputProductName.setSelection(max(start, before)) // 커서를 입력하고 있던 곳에
                     Toast.makeText(requireContext(), getString(R.string.notice_product_name_max_length), Toast.LENGTH_SHORT).show()
                 }
             }

--- a/feature/post/src/main/res/layout/fragment_image_picker.xml
+++ b/feature/post/src/main/res/layout/fragment_image_picker.xml
@@ -2,12 +2,12 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    tools:context="com.swmarastro.mykkumi.feature.post.image.ImagePickerFragment">
+    tools:context="com.swmarastro.mykkumi.feature.post.imagePicker.ImagePickerFragment">
 
     <data>
         <variable
             name="vm"
-            type="com.swmarastro.mykkumi.feature.post.image.ImagePickerViewModel" />
+            type="com.swmarastro.mykkumi.feature.post.imagePicker.ImagePickerViewModel" />
     </data>
 
     <RelativeLayout

--- a/feature/post/src/main/res/layout/fragment_post_edit.xml
+++ b/feature/post/src/main/res/layout/fragment_post_edit.xml
@@ -56,6 +56,7 @@
         </RelativeLayout>
 
         <ScrollView
+            android:id="@+id/scroll_edit_post"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_below="@id/header_post_edit">

--- a/feature/post/src/main/res/layout/fragment_post_edit.xml
+++ b/feature/post/src/main/res/layout/fragment_post_edit.xml
@@ -132,6 +132,21 @@
                     android:layout_below="@id/relative_select_post_image"
                     android:layout_alignParentRight="true"/>
 
+                <EditText
+                    android:id="@+id/edittext_input_content"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="200dp"
+                    android:hint="@string/placeholder_input_post_content"
+                    android:textColor="@color/black"
+                    android:textColorHint="@color/gray_86"
+                    android:textSize="15sp"
+                    android:gravity="top"
+                    android:layout_margin="10dp"
+                    android:padding="10dp"
+                    android:layout_below="@id/btn_add_pin"
+                    android:background="@color/gray_DD"/>
+
             </RelativeLayout>
 
         </ScrollView>

--- a/feature/post/src/main/res/layout/fragment_select_hobby_of_post_bottom_sheet.xml
+++ b/feature/post/src/main/res/layout/fragment_select_hobby_of_post_bottom_sheet.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:context=".hobbyCategory.SelectHobbyOfPostBottomSheet">
+
+    <data>
+
+        <variable
+            name="vm"
+            type="com.swmarastro.mykkumi.feature.post.hobbyCategory.SelectHobbyOfPostViewModel" />
+
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/text_confirm_notice_message"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:layout_centerHorizontal="true"
+            android:text="@string/notice_select_hobby_category_of_post"
+            android:textSize="18sp"
+            android:textColor="@color/black"
+            android:textStyle="bold"
+            android:layout_marginTop="10dp"/>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerview_hobby_category"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            tools:listitem="@layout/item_hobby_category"
+            android:orientation="vertical"
+            android:nestedScrollingEnabled="false"
+            android:overScrollMode="never"/>
+
+        <Button
+            android:id="@+id/btn_done_select_hobby_category"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:padding="5dp"
+            android:text="@string/done_select_hobby_category"
+            android:textColor="@color/black"
+            android:textSize="16sp"/>
+
+    </LinearLayout>
+
+</layout>

--- a/feature/post/src/main/res/layout/item_hobby_category.xml
+++ b/feature/post/src/main/res/layout/item_hobby_category.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_margin="5dp">
+
+        <TextView
+            android:id="@+id/text_hobby_category"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="16sp"
+            android:textColor="@color/black"
+            android:textStyle="bold"/>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerview_hobby_sub_category"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+            tools:listitem="@layout/item_hobby_sub_category" />
+
+    </LinearLayout>
+
+</layout>

--- a/feature/post/src/main/res/layout/item_hobby_sub_category.xml
+++ b/feature/post/src/main/res/layout/item_hobby_sub_category.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    
+    <LinearLayout
+        android:id="@+id/linear_sub_hobby_category"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center_horizontal"
+        android:layout_margin="3dp"
+        android:padding="2dp">
+        
+        <ImageView
+            android:id="@+id/image_hobby_sub_category"
+            android:layout_width="72dp"
+            android:layout_height="72dp"
+            android:src="@drawable/img_profile_default"
+            android:scaleType="fitXY"/>
+
+        <TextView
+            android:id="@+id/text_hobby_sub_category"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:textColor="@color/black"/>
+        
+    </LinearLayout>
+
+</layout>

--- a/feature/post/src/main/res/navigation/nav_post.xml
+++ b/feature/post/src/main/res/navigation/nav_post.xml
@@ -42,24 +42,4 @@
 
     </fragment>
 
-    <fragment
-        android:id="@+id/postConfirmBottomSheet"
-        android:name="com.swmarastro.mykkumi.feature.post.confirm.PostConfirmBottomSheet"
-        android:label="bottom_sheet_post_confirm"
-        tools:layout="@layout/fragment_confirm_bottom_sheet">
-
-<!--        <argument-->
-<!--            android:name="message"-->
-<!--            app:argType="string"/>-->
-
-<!--        <argument-->
-<!--            android:name="callback"-->
-<!--            app:argType="boolean"-->
-<!--            android:defaultValue="false"/>-->
-
-<!--        <deepLink-->
-<!--            app:uri="mykkumi://post.confirm?message={message}&amp;callback={callback}" />-->
-
-    </fragment>
-
 </navigation>

--- a/feature/post/src/main/res/navigation/nav_post.xml
+++ b/feature/post/src/main/res/navigation/nav_post.xml
@@ -22,13 +22,13 @@
 
     <fragment
         android:id="@+id/imagePickerFragment"
-        android:name="com.swmarastro.mykkumi.feature.post.image.ImagePickerFragment"
+        android:name="com.swmarastro.mykkumi.feature.post.imagePicker.ImagePickerFragment"
         android:label="fragment_image_picker"
         tools:layout="@layout/fragment_image_picker">
 
         <argument
             android:name="selectImages"
-            app:argType="com.swmarastro.mykkumi.feature.post.image.ImagePickerArgument"
+            app:argType="com.swmarastro.mykkumi.feature.post.imagePicker.ImagePickerArgument"
             app:nullable="true"
             android:defaultValue="@null"/>
 

--- a/feature/post/src/main/res/values/dimens.xml
+++ b/feature/post/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="item_hobby_sub_category">82dp</dimen>
+</resources>

--- a/feature/post/src/main/res/values/strings.xml
+++ b/feature/post/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="post_edit_title">상품 태그 입력</string>
     <string name="upload_post">등록</string>
     <string name="done_image_picker">선택 완료</string>
+    <string name="done_select_hobby_category">완료</string>
     <string name="image_picker_title">이미지 선택</string>
     <string name="notice_not_select_image">이미지를 선택해주세요</string>
 
@@ -17,4 +18,5 @@
     <string name="placeholder_input_post_content">내용을 작성해주세요.</string>
     <string name="notice_post_content_max_length">내용은 2000자 이내로 입력해주세요.</string>
     <string name="notice_post_hashtag_max_count">해시태그는 최대 20개까지 사용 가능합니다.</string>
+    <string name="notice_select_hobby_category_of_post">취미 카테고리를 선택해주세요.</string>
 </resources>

--- a/feature/post/src/main/res/values/strings.xml
+++ b/feature/post/src/main/res/values/strings.xml
@@ -14,4 +14,7 @@
     <string name="placeholder_product_url_for_input_product_info">https://...</string>
     <string name="notice_product_name_not_null">제품명을 입력해주세요.</string>
     <string name="notice_product_name_max_length">제품명은 20자 이내로 입력해주세요.</string>
+    <string name="placeholder_input_post_content">내용을 작성해주세요.</string>
+    <string name="notice_post_content_max_length">내용은 2000자 이내로 입력해주세요.</string>
+    <string name="notice_post_hashtag_max_count">해시태그는 최대 20개까지 사용 가능합니다.</string>
 </resources>


### PR DESCRIPTION
## 구현내용
### 1. 포스트 작성 > 본문 내용
- 본문 입력
- 글자 수 제한 2000자
- 해시태그 20개 제한

### 2. 포스트 작성 > 카테고리 선택
- 포스트 등록 버튼 선택 시, 카테고리 선택을 위한 BottomSheet show
- BottomSheet에서 카테고리 선택 후 완료 버튼

## 고민사항
### 1. 핀 이동 시 스크롤
- 구현 기능과는 다른 부분이지만, 핀 이동할 때 수직 스크롤을 막는 방법을 시도 중입니다
- ViewPager의 수평스크롤은 막아뒀는데,
- 본문 내용 작성하는 칸이 생기면서 수직 스크롤도 추가되어서 수직 스크롤도 막을 필요가 생겼습니다
- 그런데 ScrollView의 isEnabled를 false로 해줬는데도 스크롤이 동작되어서 액션을 어떻게 막아야 할지 방법을 찾고 있습니다

### 2. BottomSheetDialogFragment
- 새롭게 추가되는 Fragment 간의 이동 액션은 DeepLink로 구현하려고 하고 있는데,
- BottomSheetDialogFragment는 DeepLink로 구현했을 때,
- 아래에서 올라오는 BottomSheet 형태가 아니라 Fragment처럼 화면이 꽉 차는 형태가 되어서 결국 아래처럼 구현했습니다

```kotlin
val bundle = Bundle()
bundle.putString("message", message)
bundle.putInt("position", position)
val bottomSheet = PostConfirmBottomSheet().apply { setListener(fragment) }
bottomSheet.arguments = bundle
bottomSheet.show(fragment.parentFragmentManager, bottomSheet.tag)
```
- DeepLink로 구현하는 방법을 더 찾아보고, 안 되면 Navigation Graph Action으로라도 변경할 수 있도록 하겠습니다