### PR TITLE
[FEAT/REFACTOR] KKUMI-93 #56: 이미지 > PreSignedUrl

### DIFF
--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/datasource/PreSignedUrlDataSource.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/datasource/PreSignedUrlDataSource.kt
@@ -1,0 +1,12 @@
+package com.swmarastro.mykkumi.data.datasource
+
+import com.swmarastro.mykkumi.data.dto.response.PreSignedUrlDTO
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface PreSignedUrlDataSource {
+    @GET("/api/v1/posts/preSignedUrl")
+    suspend fun getPreSignedUrl(
+        @Query("extension") extension: String = "jpeg" // 확장자
+    ) : PreSignedUrlDTO
+}

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/datasource/PutImageS3DataSource.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/datasource/PutImageS3DataSource.kt
@@ -1,14 +1,14 @@
 package com.swmarastro.mykkumi.data.datasource
 
 import okhttp3.MultipartBody
-import retrofit2.http.Body
 import retrofit2.http.PUT
+import retrofit2.http.Part
 import retrofit2.http.Url
 
 interface PutImageS3DataSource {
     @PUT
     suspend fun putImageForS3(
         @Url url: String, // api url
-        @Body params: MultipartBody.Part,
+        @Part file: MultipartBody.Part,
     )
 }

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/datasource/PutImageS3DataSource.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/datasource/PutImageS3DataSource.kt
@@ -1,13 +1,8 @@
 package com.swmarastro.mykkumi.data.datasource
 
-import okhttp3.MultipartBody
 import okhttp3.RequestBody
-import okhttp3.ResponseBody
-import retrofit2.Response
 import retrofit2.http.Body
-import retrofit2.http.Multipart
 import retrofit2.http.PUT
-import retrofit2.http.Part
 import retrofit2.http.Url
 
 interface PutImageS3DataSource {

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/datasource/PutImageS3DataSource.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/datasource/PutImageS3DataSource.kt
@@ -1,0 +1,14 @@
+package com.swmarastro.mykkumi.data.datasource
+
+import okhttp3.MultipartBody
+import retrofit2.http.Body
+import retrofit2.http.PUT
+import retrofit2.http.Url
+
+interface PutImageS3DataSource {
+    @PUT
+    suspend fun putImageForS3(
+        @Url url: String, // api url
+        @Body params: MultipartBody.Part,
+    )
+}

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/datasource/PutImageS3DataSource.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/datasource/PutImageS3DataSource.kt
@@ -1,6 +1,7 @@
 package com.swmarastro.mykkumi.data.datasource
 
 import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import okhttp3.ResponseBody
 import retrofit2.Response
 import retrofit2.http.Body
@@ -11,10 +12,9 @@ import retrofit2.http.Url
 
 interface PutImageS3DataSource {
 
-    @Multipart
     @PUT
     suspend fun putImageForS3(
         @Url url: String, // preSigned url
-        @Part file: MultipartBody.Part
+        @Body image: RequestBody
     )
 }

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/datasource/PutImageS3DataSource.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/datasource/PutImageS3DataSource.kt
@@ -1,6 +1,8 @@
 package com.swmarastro.mykkumi.data.datasource
 
 import okhttp3.MultipartBody
+import okhttp3.ResponseBody
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Multipart
 import retrofit2.http.PUT
@@ -13,6 +15,6 @@ interface PutImageS3DataSource {
     @PUT
     suspend fun putImageForS3(
         @Url url: String, // preSigned url
-        @Body params: MultipartBody.Part,
+        @Part file: MultipartBody.Part
     )
 }

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/datasource/PutImageS3DataSource.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/datasource/PutImageS3DataSource.kt
@@ -1,14 +1,18 @@
 package com.swmarastro.mykkumi.data.datasource
 
 import okhttp3.MultipartBody
+import retrofit2.http.Body
+import retrofit2.http.Multipart
 import retrofit2.http.PUT
 import retrofit2.http.Part
 import retrofit2.http.Url
 
 interface PutImageS3DataSource {
+
+    @Multipart
     @PUT
     suspend fun putImageForS3(
-        @Url url: String, // api url
-        @Part file: MultipartBody.Part,
+        @Url url: String, // preSigned url
+        @Body params: MultipartBody.Part,
     )
 }

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/datasource/UserInfoDataSource.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/datasource/UserInfoDataSource.kt
@@ -1,9 +1,11 @@
 package com.swmarastro.mykkumi.data.datasource
 
+import com.swmarastro.mykkumi.data.dto.request.UpdateUserInfoRequestDTO
 import com.swmarastro.mykkumi.data.dto.response.UpdateUserInfoResponseDTO
 import com.swmarastro.mykkumi.data.dto.response.UserInfoDTO
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
+import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Multipart
@@ -15,13 +17,8 @@ interface UserInfoDataSource {
     suspend fun getUserInfo(
     ) : UserInfoDTO
 
-    @Multipart
     @PATCH("/api/v1/users")
     suspend fun updateUserInfo(
-//        @Body params: UpdateUserInfoRequestDTO,
-        @Part("nickname") nickname: RequestBody?,
-        @Part profileImage: MultipartBody.Part?,
-        @Part("introduction") introduction: RequestBody?,
-        @Part("categoryIds") categoryIds: RequestBody?
+        @Body params: UpdateUserInfoRequestDTO,
     ) : UpdateUserInfoResponseDTO
 }

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/datastore/AuthTokenDataStoreImpl.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/datastore/AuthTokenDataStoreImpl.kt
@@ -1,6 +1,7 @@
 package com.swmarastro.mykkumi.data.datastore
 
 import android.content.Context
+import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
 import com.swmarastro.mykkumi.domain.datastore.AuthTokenDataStore
@@ -40,9 +41,13 @@ class AuthTokenDataStoreImpl @Inject constructor(
         return sharedPreferences.getString(REFRESH_TOKEN, null)
     }
 
+    override fun deleteAccessToken() {
+        sharedPreferences.edit().remove(ACCESS_TOKEN).apply()
+    }
+
     override fun deleteToken() {
-        sharedPreferences.edit().remove(ACCESS_TOKEN)
-        sharedPreferences.edit().remove(REFRESH_TOKEN)
+        sharedPreferences.edit().remove(ACCESS_TOKEN).apply()
+        sharedPreferences.edit().remove(REFRESH_TOKEN).apply()
     }
 
     override fun isLogin(): Boolean { // 로그인 유무 = Token 존재 유무

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/di/NetworkModule.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/di/NetworkModule.kt
@@ -87,7 +87,7 @@ object NetworkModule {
     @Named("S3Retrofit")
     fun provideS3Retrofit(okHttpClient: OkHttpClient) : Retrofit {
         return Retrofit.Builder()
-            .baseUrl("")
+            .baseUrl("https://dummy.base.url/")
             .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create())
             .build()

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/di/NetworkModule.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/di/NetworkModule.kt
@@ -15,6 +15,8 @@ import com.swmarastro.mykkumi.data.datasource.BannerDataSource
 import com.swmarastro.mykkumi.data.datasource.HobbyCategoryDataSource
 import com.swmarastro.mykkumi.data.datasource.KakaoLoginDataSource
 import com.swmarastro.mykkumi.data.datasource.PostDataSource
+import com.swmarastro.mykkumi.data.datasource.PreSignedUrlDataSource
+import com.swmarastro.mykkumi.data.datasource.PutImageS3DataSource
 import com.swmarastro.mykkumi.data.datasource.ReAccessTokenDataSource
 import com.swmarastro.mykkumi.data.datasource.UserInfoDataSource
 import com.swmarastro.mykkumi.data.interceptor.TokenAuthenticator
@@ -23,6 +25,7 @@ import com.swmarastro.mykkumi.data.util.KakaoInitializer
 import com.swmarastro.mykkumi.domain.datastore.AuthTokenDataStore
 import com.swmarastro.mykkumi.domain.repository.ReAccessTokenRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Named
 import javax.inject.Provider
 
 /*
@@ -79,6 +82,17 @@ object NetworkModule {
             .build()
     }
 
+    @Provides
+    @Singleton
+    @Named("S3Retrofit")
+    fun provideS3Retrofit(okHttpClient: OkHttpClient) : Retrofit {
+        return Retrofit.Builder()
+            .baseUrl("")
+            .client(okHttpClient)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+
     // 카카오 sdk init을 위한
     @Provides
     @Singleton
@@ -120,5 +134,17 @@ object NetworkModule {
     @Singleton
     fun provideHobbyCategoryDataSource(retrofit: Retrofit): HobbyCategoryDataSource {
         return retrofit.create(HobbyCategoryDataSource::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun preSignedUrlDataSource(retrofit: Retrofit): PreSignedUrlDataSource {
+        return retrofit.create(PreSignedUrlDataSource::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun putImageS3DataSource(@Named("S3Retrofit") retrofit: Retrofit): PutImageS3DataSource {
+        return retrofit.create(PutImageS3DataSource::class.java)
     }
 }

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/di/NetworkModule.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/di/NetworkModule.kt
@@ -73,6 +73,17 @@ object NetworkModule {
 
     @Provides
     @Singleton
+    @Named("S3Retrofit")
+    fun provideS3OkHttpClient(
+        httpLoggingInterceptor: HttpLoggingInterceptor,
+    ) : OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor(httpLoggingInterceptor)
+            .build()
+    }
+
+    @Provides
+    @Singleton
     fun provideRetrofit(okHttpClient: OkHttpClient) : Retrofit {
         return Retrofit.Builder()
             .baseUrl(BASE_URL)
@@ -85,7 +96,7 @@ object NetworkModule {
     @Provides
     @Singleton
     @Named("S3Retrofit")
-    fun provideS3Retrofit(okHttpClient: OkHttpClient) : Retrofit {
+    fun provideS3Retrofit(@Named("S3Retrofit") okHttpClient: OkHttpClient) : Retrofit {
         return Retrofit.Builder()
             .baseUrl("https://dummy.base.url/")
             .client(okHttpClient)

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/di/RepositoryModule.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/di/RepositoryModule.kt
@@ -46,7 +46,6 @@ interface RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindsUserInfoRepository(
-//        @ApplicationContext context: Context,
         userInfoRepositoryImpl: UserInfoRepositoryImpl
     ): UserInfoRepository
 

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/di/RepositoryModule.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/di/RepositoryModule.kt
@@ -4,12 +4,14 @@ import com.swmarastro.mykkumi.data.repository.BannerRepositoryImpl
 import com.swmarastro.mykkumi.data.repository.HobbyCategoryRepositoryImpl
 import com.swmarastro.mykkumi.data.repository.KakaoLoginRepositoryImpl
 import com.swmarastro.mykkumi.data.repository.PostRepositoryImpl
+import com.swmarastro.mykkumi.data.repository.PreSignedUrlRepositoryImpl
 import com.swmarastro.mykkumi.data.repository.ReAccessTokenRepositoryImpl
 import com.swmarastro.mykkumi.data.repository.UserInfoRepositoryImpl
 import com.swmarastro.mykkumi.domain.repository.BannerRepository
 import com.swmarastro.mykkumi.domain.repository.HobbyCategoryRepository
 import com.swmarastro.mykkumi.domain.repository.KakaoLoginRepository
 import com.swmarastro.mykkumi.domain.repository.PostRepository
+import com.swmarastro.mykkumi.domain.repository.PreSignedUrlRepository
 import com.swmarastro.mykkumi.domain.repository.ReAccessTokenRepository
 import com.swmarastro.mykkumi.domain.repository.UserInfoRepository
 import dagger.Binds
@@ -59,4 +61,10 @@ interface RepositoryModule {
     abstract fun bindsHobbyCategoryRepository(
         hobbyCategoryRepositoryImpl: HobbyCategoryRepositoryImpl
     ): HobbyCategoryRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindsPreSignedUrlRepository(
+        preSignedUrlRepositoryImpl: PreSignedUrlRepositoryImpl
+    ): PreSignedUrlRepository
 }

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/dto/request/UserInfoRequestDTO.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/dto/request/UserInfoRequestDTO.kt
@@ -1,14 +1,13 @@
 package com.swmarastro.mykkumi.data.dto.request
 
 import com.google.gson.annotations.SerializedName
-import okhttp3.MultipartBody
 
 data class UpdateUserInfoRequestDTO(
     @SerializedName("nickname")
     val nickname: String?,
 
     @SerializedName("profileImage")
-    val profileImage: MultipartBody.Part?,
+    val profileImage: String?,
 
     @SerializedName("introduction")
     val introduction: String?,

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/dto/response/PreSignedUrlDTO.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/dto/response/PreSignedUrlDTO.kt
@@ -1,0 +1,8 @@
+package com.swmarastro.mykkumi.data.dto.response
+
+import com.google.gson.annotations.SerializedName
+
+data class PreSignedUrlDTO(
+    @SerializedName("posts")
+    val url: String
+)

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/dto/response/PreSignedUrlDTO.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/dto/response/PreSignedUrlDTO.kt
@@ -3,6 +3,6 @@ package com.swmarastro.mykkumi.data.dto.response
 import com.google.gson.annotations.SerializedName
 
 data class PreSignedUrlDTO(
-    @SerializedName("posts")
+    @SerializedName("url")
     val url: String
 )

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/interceptor/TokenAuthenticator.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/interceptor/TokenAuthenticator.kt
@@ -1,5 +1,6 @@
 package com.swmarastro.mykkumi.data.interceptor
 
+import android.util.Log
 import com.swmarastro.mykkumi.domain.datastore.AuthTokenDataStore
 import com.swmarastro.mykkumi.domain.repository.ReAccessTokenRepository
 import kotlinx.coroutines.runBlocking
@@ -29,7 +30,7 @@ class TokenAuthenticator @Inject constructor(
 
         // 연속 호출 횟수 제한 - RefreshToken까지 만료되었을 경우 무한 호출에 빠질 가능성이 있음
         if (responseCount(response) >= MAX_RETRY_COUNT) {
-            return null
+            authTokenDataSource.deleteToken()
         }
 
         return runBlocking {

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/repository/KakaoLoginRepositoryImpl.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/repository/KakaoLoginRepositoryImpl.kt
@@ -19,6 +19,7 @@ class KakaoLoginRepositoryImpl @Inject constructor(
             refreshToken = kakaoLoginToken.refreshToken,
             accessToken = kakaoLoginToken.accessToken
         )
+
         val mykkumiLoginResponse : MykkumiLoginResponseDTO = kakaoLoginDataSource.signInKakao(kakaoLoginTokenRequest)
 
         // 로그인 완료 후 token 값 받기 성공

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/repository/PreSignedUrlRepositoryImpl.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/repository/PreSignedUrlRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package com.swmarastro.mykkumi.data.repository
+
+import android.util.Log
+import com.swmarastro.mykkumi.data.datasource.PreSignedUrlDataSource
+import com.swmarastro.mykkumi.domain.repository.PreSignedUrlRepository
+import javax.inject.Inject
+
+class PreSignedUrlRepositoryImpl @Inject constructor(
+    private val preSignedUrlDataSource: PreSignedUrlDataSource
+) : PreSignedUrlRepository {
+    override suspend fun getPreSignedUrl(): String {
+        val preSignedUrlResponse = preSignedUrlDataSource.getPreSignedUrl()
+        //Log.d("test", preSignedUrlResponse.url)
+        return ""
+    }
+}

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/repository/PreSignedUrlRepositoryImpl.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/repository/PreSignedUrlRepositoryImpl.kt
@@ -1,16 +1,43 @@
 package com.swmarastro.mykkumi.data.repository
 
+import android.content.Context
 import android.util.Log
+import android.widget.Toast
 import com.swmarastro.mykkumi.data.datasource.PreSignedUrlDataSource
+import com.swmarastro.mykkumi.data.datasource.PutImageS3DataSource
+import com.swmarastro.mykkumi.data.util.FormDataUtil
 import com.swmarastro.mykkumi.domain.repository.PreSignedUrlRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class PreSignedUrlRepositoryImpl @Inject constructor(
-    private val preSignedUrlDataSource: PreSignedUrlDataSource
+    @ApplicationContext private val context: Context,
+    private val preSignedUrlDataSource: PreSignedUrlDataSource,
+    private val putImageS3DataSource: PutImageS3DataSource,
 ) : PreSignedUrlRepository {
-    override suspend fun getPreSignedUrl(): String {
+    override suspend fun getPreSignedUrl(imageLocalUri: Any): String? {
         val preSignedUrlResponse = preSignedUrlDataSource.getPreSignedUrl()
-        //Log.d("test", preSignedUrlResponse.url)
-        return ""
+
+        val imageFile = FormDataUtil.convertUriToMultipart(context, imageLocalUri)
+
+        if(imageFile == null) {
+            Toast.makeText(context, "손상된 이미지입니다.", Toast.LENGTH_SHORT).show()
+
+            return null
+        }
+        else {
+            try {
+                Log.d("test", "----------------")
+                putImageS3DataSource.putImageForS3(
+                    preSignedUrlResponse.url,
+                    imageFile
+                )
+
+                val imageUrl: String = preSignedUrlResponse.url.split("?")[0]
+                return imageUrl
+            } catch (e: Exception) {
+                return null
+            }
+        }
     }
 }

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/repository/PreSignedUrlRepositoryImpl.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/repository/PreSignedUrlRepositoryImpl.kt
@@ -8,6 +8,8 @@ import com.swmarastro.mykkumi.data.datasource.PutImageS3DataSource
 import com.swmarastro.mykkumi.data.util.FormDataUtil
 import com.swmarastro.mykkumi.domain.repository.PreSignedUrlRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class PreSignedUrlRepositoryImpl @Inject constructor(
@@ -16,28 +18,29 @@ class PreSignedUrlRepositoryImpl @Inject constructor(
     private val putImageS3DataSource: PutImageS3DataSource,
 ) : PreSignedUrlRepository {
     override suspend fun getPreSignedUrl(imageLocalUri: Any): String? {
-        val preSignedUrlResponse = preSignedUrlDataSource.getPreSignedUrl()
+        try {
+            val preSignedUrlResponse = preSignedUrlDataSource.getPreSignedUrl()
 
-        val imageFile = FormDataUtil.convertUriToMultipart(context, imageLocalUri)
+            val imageFile = FormDataUtil.convertUriToMultipart(context, imageLocalUri)
 
-        if(imageFile == null) {
-            Toast.makeText(context, "손상된 이미지입니다.", Toast.LENGTH_SHORT).show()
-
-            return null
-        }
-        else {
-            try {
-                Log.d("test", "----------------")
-                putImageS3DataSource.putImageForS3(
-                    preSignedUrlResponse.url,
-                    imageFile
-                )
-
-                val imageUrl: String = preSignedUrlResponse.url.split("?")[0]
-                return imageUrl
-            } catch (e: Exception) {
+            if (imageFile == null) {
+                Toast.makeText(context, "손상된 이미지입니다.", Toast.LENGTH_SHORT).show()
                 return null
+            } else {
+                try {
+                    putImageS3DataSource.putImageForS3(
+                        preSignedUrlResponse.url,
+                        imageFile
+                    )
+
+                    val imageUrl: String = preSignedUrlResponse.url.split("?")[0]
+                    return imageUrl
+                } catch (e: Exception) {
+                    return null
+                }
             }
+        } catch (e: Exception) {
+            return null
         }
     }
 }

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/repository/PreSignedUrlRepositoryImpl.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/repository/PreSignedUrlRepositoryImpl.kt
@@ -21,7 +21,7 @@ class PreSignedUrlRepositoryImpl @Inject constructor(
         try {
             val preSignedUrlResponse = preSignedUrlDataSource.getPreSignedUrl()
 
-            val imageFile = FormDataUtil.convertUriToMultipart(context, imageLocalUri)
+            val imageFile = FormDataUtil.convertUriToRequestBody(context, imageLocalUri)
 
             if (imageFile == null) {
                 Toast.makeText(context, "손상된 이미지입니다.", Toast.LENGTH_SHORT).show()

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/repository/ReAccessTokenRepositoryImpl.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/repository/ReAccessTokenRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.swmarastro.mykkumi.data.repository
 
+import android.util.Log
 import com.google.gson.Gson
 import com.swmarastro.mykkumi.data.datasource.ReAccessTokenDataSource
 import com.swmarastro.mykkumi.data.dto.request.ReAccessTokenRequestDTO
@@ -45,6 +46,7 @@ class ReAccessTokenRepositoryImpl @Inject constructor(
 
         when (errorResponse.errorCode) {
             INVALID_TOKEN -> { // 토큰 삭제 - 로그아웃
+                Log.d("test", "delete token ------------------")
                 authTokenDataSource.deleteToken()
                 throw ApiException.InvalidRefreshTokenException()
             }

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/repository/UserInfoRepositoryImpl.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/repository/UserInfoRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.swmarastro.mykkumi.data.repository
 import android.content.Context
 import com.google.gson.Gson
 import com.swmarastro.mykkumi.data.datasource.UserInfoDataSource
+import com.swmarastro.mykkumi.data.dto.request.UpdateUserInfoRequestDTO
 import com.swmarastro.mykkumi.domain.exception.ApiException
 import com.swmarastro.mykkumi.data.util.FormDataUtil
 import com.swmarastro.mykkumi.domain.exception.ErrorResponse
@@ -36,25 +37,16 @@ class UserInfoRepositoryImpl @Inject constructor(
     }
 
     override suspend fun updateUserInfo(userInfo: UpdateUserInfoRequestVO): UpdateUserInfoResponseVO {
-//        val userInfoDTO = UpdateUserInfoRequestDTO(
-//            nickname = userInfo.nickname,
-//            profileImage = FormDataUtil.convertUriToMultipart(context, userInfo.profileImage), // Uri를 Multipart/form-data로 변환
-//            introduction = userInfo.introduction,
-//            categoryIds = userInfo.categoryIds
-//        )
-//
-//        Log.d("repository", userInfoDTO.toString())
-
-//        val imageMultipart = FormDataUtil.convertUriToMultipart(context, userInfo.profileImage)
-//        Log.d("imager multipart", imageMultipart.toString())
+        val userInfoDTO = UpdateUserInfoRequestDTO(
+            nickname = userInfo.nickname,
+            profileImage = userInfo.profileImage,
+            introduction = userInfo.introduction,
+            categoryIds = userInfo.categoryIds
+        )
 
         return try {
             userInfoDataSource.updateUserInfo(
-//            params = userInfoDTO
-                nickname = FormDataUtil.getBody(userInfo.nickname),
-                profileImage = FormDataUtil.convertUriToMultipart(context, userInfo.profileImage),
-                introduction = FormDataUtil.getBody(userInfo.introduction),
-                categoryIds = null //FormDataUtil.getListLongBody(listOf<Long>(1, 2))
+                params = userInfoDTO
             ).toEntity()
         } catch (e: HttpException) {
             handleApiException(e)

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/repository/UserInfoRepositoryImpl.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/repository/UserInfoRepositoryImpl.kt
@@ -1,22 +1,18 @@
 package com.swmarastro.mykkumi.data.repository
 
-import android.content.Context
 import com.google.gson.Gson
 import com.swmarastro.mykkumi.data.datasource.UserInfoDataSource
 import com.swmarastro.mykkumi.data.dto.request.UpdateUserInfoRequestDTO
 import com.swmarastro.mykkumi.domain.exception.ApiException
-import com.swmarastro.mykkumi.data.util.FormDataUtil
 import com.swmarastro.mykkumi.domain.exception.ErrorResponse
 import com.swmarastro.mykkumi.domain.entity.UpdateUserInfoRequestVO
 import com.swmarastro.mykkumi.domain.entity.UpdateUserInfoResponseVO
 import com.swmarastro.mykkumi.domain.entity.UserInfoVO
 import com.swmarastro.mykkumi.domain.repository.UserInfoRepository
-import dagger.hilt.android.qualifiers.ApplicationContext
 import retrofit2.HttpException
 import javax.inject.Inject
 
 class UserInfoRepositoryImpl @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val userInfoDataSource: UserInfoDataSource,
 ) :UserInfoRepository {
 
@@ -25,8 +21,6 @@ class UserInfoRepositoryImpl @Inject constructor(
         private const val DUPLICATE_VALUE = "DUPLICATE_VALUE"
         private const val INVALID_VALUE = "INVALID_VALUE"
     }
-
-    //private var authorization = authTokenDataSource.getAccessToken()
 
     override suspend fun getUserInfo(): UserInfoVO {
         return try {

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/util/FormDataUtil.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/util/FormDataUtil.kt
@@ -21,19 +21,15 @@ object FormDataUtil {
     private val MAX_IMAGE_SIZE = 1024
 
     // Uri를 Multipart/form-data로 변환
-    fun convertUriToMultipart(context: Context, image: Any?): MultipartBody.Part? {
-        val imageUri = anyToUri(image)
-
-        Log.d("test url", imageUri.toString())
-
-        if(imageUri == null) return null
+    fun convertUriToMultipart(context: Context, imageUri: Any?): MultipartBody.Part? {
+        val imageUri = imageUri as Uri
 
         val file = uriToFile(context, imageUri)
 
         if(file == null || !file.exists()) return null
 
         val requestFile = file.asRequestBody("image/*".toMediaType())
-        return MultipartBody.Part.createFormData("profileImage", file.name, requestFile)
+        return MultipartBody.Part.createFormData("file", file.name, requestFile)
     }
 
     // Content URI를 파일로 변환하는 함수
@@ -96,23 +92,6 @@ object FormDataUtil {
             }
         }
         return name
-    }
-
-    fun getBody(value: String?): RequestBody? {
-        return value?.toRequestBody("text/plain".toMediaType())
-    }
-
-    fun getListLongBody(value: List<Long>?): RequestBody? {
-        val json = Gson().toJson(value)
-        return json.toRequestBody("application/json; charset=utf-8".toMediaType())
-    }
-
-    fun anyToUri(imageUri: Any?): Uri? {
-        return if(imageUri is Uri) {
-            imageUri
-        } else {
-            null
-        }
     }
 }
 

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/util/FormDataUtil.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/util/FormDataUtil.kt
@@ -89,9 +89,6 @@ object FormDataUtil {
             newHeight = MAX_IMAGE_SIZE
         }
 
-        Log.d("test", "image width: ${width}, height: ${height}")
-        Log.d("test", "image width: ${newWidth}, height: ${newHeight}")
-
         return Bitmap.createScaledBitmap(bitmap, newWidth, newHeight, true)
     }
 

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/util/FormDataUtil.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/util/FormDataUtil.kt
@@ -21,7 +21,7 @@ object FormDataUtil {
     private val MAX_IMAGE_SIZE = 1024
 
     // Uri를 Multipart/form-data로 변환
-    fun convertUriToMultipart(context: Context, imageUri: Any?): MultipartBody.Part? {
+    fun convertUriToRequestBody(context: Context, imageUri: Any?): RequestBody? {
         val imageUri = imageUri as Uri
 
         val file = uriToFile(context, imageUri)
@@ -29,7 +29,7 @@ object FormDataUtil {
         if(file == null || !file.exists()) return null
 
         val requestFile = file.asRequestBody("image/*".toMediaType())
-        return MultipartBody.Part.createFormData("file", file.name, requestFile)
+        return requestFile
     }
 
     // Content URI를 파일로 변환하는 함수
@@ -45,8 +45,8 @@ object FormDataUtil {
             inputStream?.close()
 
             val outputStream = FileOutputStream(tempFile)
-            // 압축 품질 0~100 - 낮을수록 더 많이 압축됨 -> 압축 X
-            bitmap?.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
+            // 압축 품질 0~100 - 낮을수록 더 많이 압축됨
+            bitmap?.compress(Bitmap.CompressFormat.JPEG, 80, outputStream)
             outputStream.close()
         } catch (e: Exception) {
             Log.e("FormDataUtil", "Error converting URI to File: ${e.message}")
@@ -82,7 +82,7 @@ object FormDataUtil {
 
     // 파일 이름을 얻는 함수
     private fun getFileName(contentResolver: ContentResolver, uri: Uri): String {
-        var name = "file"
+        var name = "image"
         val cursor = contentResolver.query(uri, null, null, null, null)
         cursor?.use {
             if (cursor.moveToFirst()) {

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/util/FormDataUtil.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/util/FormDataUtil.kt
@@ -63,25 +63,26 @@ object FormDataUtil {
         val width = originalBitmap.width
         val height = originalBitmap.height
 
-        val aspectRatio: Float = width.toFloat() / height.toFloat()
-
         val newWidth: Int
         val newHeight: Int
 
         if (width > height) {
             newWidth = MAX_IMAGE_SIZE
-            newHeight = (MAX_IMAGE_SIZE / aspectRatio).toInt()
+            newHeight = (MAX_IMAGE_SIZE / (width.toFloat() / height.toFloat())).toInt()
         } else {
-            newWidth = (MAX_IMAGE_SIZE * aspectRatio).toInt()
+            newWidth = (MAX_IMAGE_SIZE / (height.toFloat() / width.toFloat())).toInt()
             newHeight = MAX_IMAGE_SIZE
         }
+
+        Log.d("test", "image width: ${width}, height: ${height}")
+        Log.d("test", "image width: ${newWidth}, height: ${newHeight}")
 
         return Bitmap.createScaledBitmap(originalBitmap, newWidth, newHeight, true)
     }
 
     // 파일 이름을 얻는 함수
     private fun getFileName(contentResolver: ContentResolver, uri: Uri): String {
-        var name = "temp_file"
+        var name = "file"
         val cursor = contentResolver.query(uri, null, null, null, null)
         cursor?.use {
             if (cursor.moveToFirst()) {

--- a/core/domain/src/main/java/com/swmarastro/mykkumi/domain/datastore/AuthTokenDataStore.kt
+++ b/core/domain/src/main/java/com/swmarastro/mykkumi/domain/datastore/AuthTokenDataStore.kt
@@ -5,6 +5,7 @@ interface AuthTokenDataStore {
     fun saveRefreshToken(refreshToken: String)
     fun getAccessToken(): String?
     fun getRefreshToken(): String?
+    fun deleteAccessToken()
     fun deleteToken()
     fun isLogin(): Boolean
 }

--- a/core/domain/src/main/java/com/swmarastro/mykkumi/domain/entity/UserInfoVO.kt
+++ b/core/domain/src/main/java/com/swmarastro/mykkumi/domain/entity/UserInfoVO.kt
@@ -9,7 +9,7 @@ data class UserInfoVO (
 
 data class UpdateUserInfoRequestVO(
     val nickname: String?,
-    val profileImage: Any?, // Uri
+    val profileImage: String?,
     val introduction: String?,
     val categoryIds: List<Long>?
 )

--- a/core/domain/src/main/java/com/swmarastro/mykkumi/domain/repository/PreSignedUrlRepository.kt
+++ b/core/domain/src/main/java/com/swmarastro/mykkumi/domain/repository/PreSignedUrlRepository.kt
@@ -1,5 +1,5 @@
 package com.swmarastro.mykkumi.domain.repository
 
 interface PreSignedUrlRepository {
-    suspend fun getPreSignedUrl(): String
+    suspend fun getPreSignedUrl(imageLocalUri: Any): String?
 }

--- a/core/domain/src/main/java/com/swmarastro/mykkumi/domain/repository/PreSignedUrlRepository.kt
+++ b/core/domain/src/main/java/com/swmarastro/mykkumi/domain/repository/PreSignedUrlRepository.kt
@@ -1,0 +1,5 @@
+package com.swmarastro.mykkumi.domain.repository
+
+interface PreSignedUrlRepository {
+    suspend fun getPreSignedUrl(): String
+}

--- a/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/LoginComposeActivity.kt
+++ b/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/LoginComposeActivity.kt
@@ -178,7 +178,6 @@ class LoginComposeActivity : ComponentActivity() {
                 if (UserApiClient.instance.isKakaoTalkLoginAvailable(activityContext)) {
                     // 카카오톡 앱이 설치되어 있고, 연결된 계정이 있는 경우 카카오톡 앱으로 로그인 시도
                     UserApiClient.instance.loginWithKakaoTalk(activityContext, callback = viewModel.kakaoCallback)
-                    //UserApiClient.instance.loginWithKakaoAccount(activityContext, callback = viewModel.kakaoCallback)
                     Log.d(TAG, "카카오톡으로 로그인")
                 } else {
                     // 카카오톡에 연결된 카카오계정이 없는 경우, 카카오계정으로 로그인 시도

--- a/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/LoginViewModel.kt
+++ b/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/LoginViewModel.kt
@@ -155,17 +155,20 @@ class LoginViewModel @Inject constructor(
                 val userInfo = getUserInfoUseCase()
                 _userInfoUiState.value = userInfo
 
-                setDoneLoginProcess()
+                viewModelScope.launch {
+                    userInfoUiState.collect { userInfo ->
+                        setDoneLoginProcess()
 
-                // 최초 가입자 -> 추가 정보 입력 페이지로
-                if(_userInfoUiState.value.nickname == null) {
-                    navController.navigate(route = LoginScreens.LoginSelectHobbyScreen.name)
-                }
-                // 기존 가입자 -> 홈 화면으로
-                else {
-                    // 테스트용
-                    //navController.navigate(route = LoginScreens.LoginSelectHobbyScreen.name)
-                    finishLogin()
+                        // 최초 가입자 -> 추가 정보 입력 페이지로
+                        if(userInfo.nickname == null) {
+                            navController.navigate(route = LoginScreens.LoginSelectHobbyScreen.name)
+                        }
+                        // 기존 가입자 -> 홈 화면으로
+                        else {
+                            finishLogin()
+                        }
+
+                    }
                 }
             }
             catch (e: ApiException.UnknownApiException) {

--- a/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/LoginViewModel.kt
+++ b/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/LoginViewModel.kt
@@ -114,7 +114,7 @@ class LoginViewModel @Inject constructor(
                 Log.e(TAG, "카카오계정으로 로그인 실패", error)
                 kakaoLoginFail()
             } else if (token != null) { // 토큰을 받아온 경우
-                Log.i(TAG, "카카오계정으로 로그인 성공 ${token.accessToken} / ${token.refreshToken} / ${token.idToken}")
+                //Log.i(TAG, "카카오계정으로 로그인 성공 ${token.accessToken} / ${token.refreshToken} / ${token.idToken}")
                 kakaoLoginSuccess()
                 setKakaoToken(token.accessToken, token.refreshToken)
             }
@@ -134,7 +134,6 @@ class LoginViewModel @Inject constructor(
                         refreshToken = refreshToken
                     )
                 )
-
 
                 if(isSuccessLogin) {
                     mykkumiLoginSuccess()

--- a/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/onBoarding/LoginInputUserScreen.kt
+++ b/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/onBoarding/LoginInputUserScreen.kt
@@ -53,6 +53,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import coil.compose.rememberAsyncImagePainter
 import coil.compose.rememberImagePainter
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.rememberMultiplePermissionsState
@@ -144,8 +145,14 @@ fun LoginInputUserScreen(
             )
             Image(
                 painter = when(loginViewModel.profileImage.collectAsState().value) {
-                    is String -> rememberImagePainter(
-                        data = loginViewModel.profileImage.collectAsState().value
+                    is String -> rememberAsyncImagePainter(
+                        model = loginViewModel.profileImage.collectAsState().value
+                    )
+                    is Int -> painterResource(
+                        id = loginViewModel.profileImage.collectAsState().value as Int
+                    )
+                    is Uri -> rememberAsyncImagePainter(
+                        model = loginViewModel.profileImage.collectAsState().value
                     )
                     else -> painterResource(
                         id = com.swmarastro.mykkumi.common_ui.R.drawable.img_profile_default

--- a/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/onBoarding/LoginInputUserScreen.kt
+++ b/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/onBoarding/LoginInputUserScreen.kt
@@ -144,10 +144,9 @@ fun LoginInputUserScreen(
             )
             Image(
                 painter = when(loginViewModel.profileImage.collectAsState().value) {
-                    is Int -> painterResource(
-                        id = loginViewModel.profileImage.collectAsState().value as Int
+                    is String -> rememberImagePainter(
+                        data = loginViewModel.profileImage.collectAsState().value
                     )
-                    is Uri -> rememberImagePainter(data = loginViewModel.profileImage.collectAsState().value)
                     else -> painterResource(
                         id = com.swmarastro.mykkumi.common_ui.R.drawable.img_profile_default
                     )

--- a/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/onBoarding/LoginInputUserViewModel.kt
+++ b/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/onBoarding/LoginInputUserViewModel.kt
@@ -1,6 +1,7 @@
 package com.swmarastro.mykkumi.feature.auth.onBoarding
 
 import android.net.Uri
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -30,8 +31,8 @@ class LoginInputUserViewModel @Inject constructor(
     private val _nickname = MutableStateFlow("")
     val nickname: StateFlow<String> get() = _nickname
 
-    private val _profileImage = MutableStateFlow<Any>(com.swmarastro.mykkumi.common_ui.R.drawable.img_profile_default)
-    val profileImage : StateFlow<Any> get() = _profileImage
+    private val _profileImage = MutableStateFlow<String>("https://avatars.githubusercontent.com/u/76805879?v=4")
+    val profileImage : StateFlow<String> get() = _profileImage
 
     // 카메라로 촬영할 이미지를 저장할 path
     private val _cameraImagePath = MutableStateFlow<Uri?>(null)
@@ -47,7 +48,7 @@ class LoginInputUserViewModel @Inject constructor(
     }
 
     fun selectProfileImage(uri: Any) {
-        _profileImage.value = uri
+        _profileImage.value = "https://avatars.githubusercontent.com/u/76805879?v=4"
         resetCameraImagePath()
     }
 

--- a/feature/home/src/main/java/com/swmarastro/mykkumi/feature/home/HomeFragment.kt
+++ b/feature/home/src/main/java/com/swmarastro/mykkumi/feature/home/HomeFragment.kt
@@ -7,6 +7,7 @@ import android.provider.Settings
 import android.util.Log
 import android.view.View
 import android.widget.ScrollView
+import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
@@ -57,6 +58,12 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
             else { // 로그인 안 됨
                 startActivity(intent)
             }
+        }
+
+        // 로그아웃 테스트
+        binding.btnShoppingCart.setOnClickListener {
+            viewModel.logout()
+            Toast.makeText(context, "개발용 로그아웃", Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/feature/home/src/main/java/com/swmarastro/mykkumi/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/swmarastro/mykkumi/feature/home/HomeViewModel.kt
@@ -126,4 +126,9 @@ class HomeViewModel @Inject constructor(
         val navigateDeepLink = "mykkumi://post.edit"
         navController?.navigate(deepLink = navigateDeepLink.toUri())
     }
+
+    // 로그아웃 테스트
+    fun logout() {
+        authTokenDataStore.deleteToken()
+    }
 }

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditFragment.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditFragment.kt
@@ -162,8 +162,6 @@ class PostEditFragment : BaseFragment<FragmentPostEditBinding>(R.layout.fragment
         initSelectPostImagesRecyclerView()
         initEditImageWithPinViewPager()
         observePostImage()
-
-        viewModel.getPresignedUrl()
     }
 
     // 선택된 이미지 리스트 Recyclerview

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditFragment.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditFragment.kt
@@ -152,6 +152,11 @@ class PostEditFragment : BaseFragment<FragmentPostEditBinding>(R.layout.fragment
             viewModel.openImagePicker(navController)
             viewModel.createViewDone() // 생성 끝
         }
+
+        // 포스트 작성 시작 후 이미지를 하나도 선택 안 한 상태로 뒤로가기 눌렀을 때 -> 이전으로 돌아가기
+        if(navController?.currentDestination?.id == R.id.postEditFragment && viewModel.selectImagePosition.value == -1) {
+            navController?.popBackStack()
+        }
     }
 
     override suspend fun initView() {

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditFragment.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditFragment.kt
@@ -162,6 +162,8 @@ class PostEditFragment : BaseFragment<FragmentPostEditBinding>(R.layout.fragment
         initSelectPostImagesRecyclerView()
         initEditImageWithPinViewPager()
         observePostImage()
+
+        viewModel.getPresignedUrl()
     }
 
     // 선택된 이미지 리스트 Recyclerview

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditViewModel.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.ViewModel
 import androidx.navigation.NavController
 import com.swmarastro.mykkumi.domain.entity.PostEditPinProductVO
 import com.swmarastro.mykkumi.domain.entity.PostEditPinVO
+import com.swmarastro.mykkumi.domain.repository.PreSignedUrlRepository
 import com.swmarastro.mykkumi.feature.post.confirm.PostConfirmBottomSheet
 import com.swmarastro.mykkumi.feature.post.hobbyCategory.SelectHobbyOfPostBottomSheet
 import com.swmarastro.mykkumi.feature.post.imageWithPin.InputProductInfoBottomSheet
@@ -22,6 +23,7 @@ import kotlin.math.max
 
 @HiltViewModel
 class PostEditViewModel  @Inject constructor(
+    private val preSignedUrlRepository: PreSignedUrlRepository
 ) : ViewModel() {
     final val MAX_IMAGE_COUNT = 10
     final val MAX_PIN_COUNT = 10
@@ -45,6 +47,11 @@ class PostEditViewModel  @Inject constructor(
         val addPostImages = _postEditUiState.value
         addPostImages?.add(PostImageData(localUri = uri))
         _postEditUiState.postValue( addPostImages!! )
+    }
+
+    suspend fun getPresignedUrl() {
+        Log.d("test","-------------------")
+        Log.d("test", preSignedUrlRepository.getPreSignedUrl())
     }
 
     fun openImagePicker(navController: NavController?) {

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditViewModel.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditViewModel.kt
@@ -2,8 +2,6 @@ package com.swmarastro.mykkumi.feature.post
 
 import android.net.Uri
 import android.os.Bundle
-import android.text.TextUtils.concat
-import android.util.Log
 import androidx.core.net.toUri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -21,7 +19,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlin.math.max
 
 @HiltViewModel
 class PostEditViewModel  @Inject constructor(
@@ -52,7 +49,7 @@ class PostEditViewModel  @Inject constructor(
 
                 if(imageUrl != null) {
                     val addPostImages = _postEditUiState.value
-                    addPostImages?.add(PostImageData(localUri = imageUrl.toUri()))
+                    addPostImages?.add(PostImageData(imageUri = imageUrl.toUri()))
                     _postEditUiState.postValue( addPostImages!! )
                 }
 

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditViewModel.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditViewModel.kt
@@ -33,7 +33,7 @@ class PostEditViewModel  @Inject constructor(
     private val _checkCreateView = MutableStateFlow<Boolean>(true)
     val checkCreateView : StateFlow<Boolean> get() = _checkCreateView
 
-    private val _selectImagePosition = MutableLiveData<Int>(0)
+    private val _selectImagePosition = MutableLiveData<Int>(-1)
     val selectImagePosition : LiveData<Int> get() = _selectImagePosition
 
     private val _currentPinList = MutableLiveData<MutableList<PostEditPinVO>>(mutableListOf())
@@ -74,12 +74,12 @@ class PostEditViewModel  @Inject constructor(
     fun changeSelectImagePosition(position: Int) {
         if(position >= 0 && _postEditUiState.value!!.size > position) {
             _postEditUiState.apply {
-                value!![selectImagePosition.value!!].isSelect = false // 이전 선택 해제
+                if(selectImagePosition.value!! >= 0) value!![selectImagePosition.value!!].isSelect = false // 이전 선택 해제
                 value!![position].isSelect = true // 새로운 선택
             }
 
-            selectImagePosition.value?.let {
-                _postEditUiState.value?.get(it)?.apply {
+            if(selectImagePosition.value!! >= 0) {
+                _postEditUiState.value?.get(selectImagePosition.value!!)?.apply {
                     pinList = currentPinList.value ?: mutableListOf()
                 }
             }

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostImageData.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostImageData.kt
@@ -5,8 +5,7 @@ import com.swmarastro.mykkumi.domain.entity.PostEditPinVO
 
 data class PostImageData(
     var imageId: Long? = null,     // 이미지 id
-    var localUri: Uri,             // 디바이스에서의 경로
-    var presignedUri: Uri? = null, // S3에 업로드된 경로
+    var imageUri: Uri?, // S3에 업로드된 경로
     var isSelect: Boolean = false, // 선택 유무
     var pinList: MutableList<PostEditPinVO>? = null // pin
 )

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/SelectPostImageListAdapter.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/SelectPostImageListAdapter.kt
@@ -69,7 +69,7 @@ class SelectPostImageListAdapter (
         private val binding: ItemSelectPostImageBinding
     ) : RecyclerView.ViewHolder(binding.root) {
         fun bind(item: PostImageData, position: Int) {
-            binding.imagePostEditThumbnail.load(item.localUri)
+            binding.imagePostEditThumbnail.load(item.imageUri)
 
             if (item.isSelect) {
                 binding.imagePostEditThumbnail.setBackgroundResource(R.drawable.shape_select_post_image)

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/hobbyCategory/SelectHobbyOfPostBottomSheet.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/hobbyCategory/SelectHobbyOfPostBottomSheet.kt
@@ -38,6 +38,7 @@ class SelectHobbyOfPostBottomSheet : BaseBottomSheetFragment<FragmentSelectHobby
 
         // 선택 완료
         binding.btnDoneSelectHobbyCategory.setOnClickListener {
+            binding.btnDoneSelectHobbyCategory.isEnabled = false // 버튼 선택 막기 -> 연속 요청 방지
             if (viewModel.selectedHobby.value == -1L)
                 Toast.makeText(context, "select_hobby_category_of_post", Toast.LENGTH_SHORT).show()
 
@@ -49,6 +50,7 @@ class SelectHobbyOfPostBottomSheet : BaseBottomSheetFragment<FragmentSelectHobby
                 }
                 dismiss()
             }
+            binding.btnDoneSelectHobbyCategory.isEnabled = true // 버튼 선택 풀기
         }
     }
 

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/imageWithPin/EditImageWithPinAdapter.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/imageWithPin/EditImageWithPinAdapter.kt
@@ -47,7 +47,7 @@ class EditImageWithPinAdapter(
         private var parentHeight = 0
 
         fun bind(item: PostImageData, position: Int) {
-            binding.imagePost.load(item.localUri)
+            binding.imagePost.load(item.imageUri)
 
             val currentPinList = if(position == viewModel.selectImagePosition.value) { // 현재 선택된, 편집 중인 이미지
                 viewModel.currentPinList.value ?: mutableListOf<PostEditPinVO>()


### PR DESCRIPTION
## 구현내용
### 1. 이미지 사이즈 조절 및 S3 업로드
- 이미지 압축: maxWidth, maxHeight를 1024px로
- PreSignedUrl 요청 (api)
- 이미지 Local Uri를 RequestBody로 변환
- 이미지를 PreSignedUrl로 S3에 업로드
- 업로드 된 url 데이터 정리 - 프로필 이미지
- 업로드 된 url 데이터 정리 - 포스트 이미지

## 고민사항
### 1. PreSigned Url로 이미지 업로드 시, Retrofit
- PreSigned Url로 이미지 업로드 시 BaseURL이 달라져서 Retrofit을 따로 두었습니다
- Header에 token이 포함되면 오류가 발생해서 OkHttpClient도 따로 두었습니다

```kotlin
@Provides
@Singleton
@Named("S3Retrofit")
fun provideS3OkHttpClient(
    httpLoggingInterceptor: HttpLoggingInterceptor,
) : OkHttpClient {
    return OkHttpClient.Builder()
        .addInterceptor(httpLoggingInterceptor)
        .build()
}

@Provides
@Singleton
@Named("S3Retrofit")
fun provideS3Retrofit(@Named("S3Retrofit") okHttpClient: OkHttpClient) : Retrofit {
    return Retrofit.Builder()
        .baseUrl("https://dummy.base.url/")
        .client(okHttpClient)
        .addConverterFactory(GsonConverterFactory.create())
        .build()
}
```
- Retrofit에서 baseUrl을 필수(Required)로 요구하는데,
- API에서 받은 URL은 `https://`부터 전체가 있기 때문에 baseUrl이 필요가 없고 아래처럼 구현할 수 있습니다

```kotlin
@PUT
suspend fun putImageForS3(
    @Url url: String, // preSigned url
    @Body image: RequestBody
)
```
- Retrofit에서 baseUrl을 아예 지우거나 "" 값으로 줄 경우 에러가 발생해서 결국 아무 의미없는 URL을 작성해두었는데, 더 좋은 방법이 있을지 고민입니다