### PR TITLE
[FIX] KKUMI-76 #70 - 포스트 작성 중 핀 이동 시, 수직 스크롤

### DIFF
--- a/core/common-ui/src/main/java/com/swmarastro/mykkumi/common_ui/custom/CustomScrollView.kt
+++ b/core/common-ui/src/main/java/com/swmarastro/mykkumi/common_ui/custom/CustomScrollView.kt
@@ -1,0 +1,23 @@
+package com.swmarastro.mykkumi.common_ui.custom
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.widget.ScrollView
+
+// 수직 스크롤 제어를 위한 커스텀 스크롤뷰
+class CustomScrollView(context: Context, attrs: AttributeSet?) : ScrollView(context, attrs) {
+    private var isScrollable = true
+
+    override fun onTouchEvent(ev: MotionEvent?): Boolean {
+        return isScrollable && super.onTouchEvent(ev)
+    }
+
+    override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
+        return isScrollable && super.onInterceptTouchEvent(ev)
+    }
+
+    fun setScrollingEnabled(enabled: Boolean) {
+        isScrollable = enabled
+    }
+}

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditFragment.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditFragment.kt
@@ -329,14 +329,14 @@ class PostEditFragment : BaseFragment<FragmentPostEditBinding>(R.layout.fragment
     // 수직 스크롤도 막기
     private fun lockViewPagerMoving() {
         binding.viewpagerPostEditImages.isUserInputEnabled = false
-        binding.scrollEditPost.isEnabled = false
+        binding.scrollEditPost.setScrollingEnabled(false)
     }
 
     // pin 이동 끝나면 viewPager 전환 가능하게 풀어주기
     // 수직 스크롤도 풀어주기
     private fun unlockViewPagerMoving() {
         binding.viewpagerPostEditImages.isUserInputEnabled = true
-        binding.scrollEditPost.isEnabled = true
+        binding.scrollEditPost.setScrollingEnabled(true)
     }
 
     // 카테고리 선택 완료 -> 포스트 작성

--- a/feature/post/src/main/res/layout/fragment_post_edit.xml
+++ b/feature/post/src/main/res/layout/fragment_post_edit.xml
@@ -55,7 +55,7 @@
 
         </RelativeLayout>
 
-        <ScrollView
+        <com.swmarastro.mykkumi.common_ui.custom.CustomScrollView
             android:id="@+id/scroll_edit_post"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -150,7 +150,7 @@
 
             </RelativeLayout>
 
-        </ScrollView>
+        </com.swmarastro.mykkumi.common_ui.custom.CustomScrollView>
 
     </RelativeLayout>
 


### PR DESCRIPTION
## 구현내용
### 1. 포스트 작성 중, 핀 이동 시 수직 스크롤 비활성 https://github.com/SW-Marastro/MyKkumi-Android/issues/70
- 핀 이동 중에는 스크롤 비활성화
- 핀 이동 중이 아닐 때는 스크롤 활성화

#### ✅ isEnabled 
```kotlin
// pin 이동 중일 때는 viewPager 전환 안 되게 막기
// 수직 스크롤도 막기
private fun lockViewPagerMoving() {
    binding.viewpagerPostEditImages.isUserInputEnabled = false
    binding.scrollEditPost.isEnabled = false
}

// pin 이동 끝나면 viewPager 전환 가능하게 풀어주기
// 수직 스크롤도 풀어주기
private fun unlockViewPagerMoving() {
    binding.viewpagerPostEditImages.isUserInputEnabled = true
    binding.scrollEditPost.isEnabled = true
}
```
핀을 이동 중인지(=터치 상태인지) 판단하여 위 함수를 호출하는 것까지는 성공.  
`binding.viewpagerPostEditImages.isUserInputEnabled = false | true`로 ViewPager의 수평 스크롤은 막을 수 있는데,  
`binding.scrollEditPost.isEnabled = false | true`로 ScrollView의 스크롤은 막히지 않음

#### ✅ Custom ScrollView로 스크롤 활성/비활성 제어
```kotlin
class CustomScrollView(context: Context, attrs: AttributeSet?) : ScrollView(context, attrs) {
    private var isScrollable = true

    override fun onTouchEvent(ev: MotionEvent?): Boolean {
        return isScrollable && super.onTouchEvent(ev)
    }

    override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
        return isScrollable && super.onInterceptTouchEvent(ev)
    }

    fun setScrollingEnabled(enabled: Boolean) {
        isScrollable = enabled
    }
}
```