### PR TITLE
[REFACTOR] KKUMI-95 #75: pre-signed url 호출하는 API를 프로필, 포스트 이미지 따로

### DIFF
--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/datasource/PreSignedUrlDataSource.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/datasource/PreSignedUrlDataSource.kt
@@ -6,7 +6,12 @@ import retrofit2.http.Query
 
 interface PreSignedUrlDataSource {
     @GET("/api/v1/posts/preSignedUrl")
-    suspend fun getPreSignedUrl(
+    suspend fun getPreSignedPostUrl(
+        @Query("extension") extension: String = "jpeg" // 확장자
+    ) : PreSignedUrlDTO
+
+    @GET("/api/v1/profileImage/preSignedUrl")
+    suspend fun getPreSignedProfileUrl(
         @Query("extension") extension: String = "jpeg" // 확장자
     ) : PreSignedUrlDTO
 }

--- a/core/data/src/main/java/com/swmarastro/mykkumi/data/repository/PreSignedUrlRepositoryImpl.kt
+++ b/core/data/src/main/java/com/swmarastro/mykkumi/data/repository/PreSignedUrlRepositoryImpl.kt
@@ -17,9 +17,36 @@ class PreSignedUrlRepositoryImpl @Inject constructor(
     private val preSignedUrlDataSource: PreSignedUrlDataSource,
     private val putImageS3DataSource: PutImageS3DataSource,
 ) : PreSignedUrlRepository {
-    override suspend fun getPreSignedUrl(imageLocalUri: Any): String? {
+    override suspend fun getPreSignedPostUrl(imageLocalUri: Any): String? {
         try {
-            val preSignedUrlResponse = preSignedUrlDataSource.getPreSignedUrl()
+            val preSignedUrlResponse = preSignedUrlDataSource.getPreSignedPostUrl()
+
+            val imageFile = FormDataUtil.convertUriToRequestBody(context, imageLocalUri)
+
+            if (imageFile == null) {
+                Toast.makeText(context, "손상된 이미지입니다.", Toast.LENGTH_SHORT).show()
+                return null
+            } else {
+                try {
+                    putImageS3DataSource.putImageForS3(
+                        preSignedUrlResponse.url,
+                        imageFile
+                    )
+
+                    val imageUrl: String = preSignedUrlResponse.url.split("?")[0]
+                    return imageUrl
+                } catch (e: Exception) {
+                    return null
+                }
+            }
+        } catch (e: Exception) {
+            return null
+        }
+    }
+
+    override suspend fun getPreSignedProfileUrl(imageLocalUri: Any): String? {
+        try {
+            val preSignedUrlResponse = preSignedUrlDataSource.getPreSignedProfileUrl()
 
             val imageFile = FormDataUtil.convertUriToRequestBody(context, imageLocalUri)
 

--- a/core/domain/src/main/java/com/swmarastro/mykkumi/domain/repository/PreSignedUrlRepository.kt
+++ b/core/domain/src/main/java/com/swmarastro/mykkumi/domain/repository/PreSignedUrlRepository.kt
@@ -1,5 +1,6 @@
 package com.swmarastro.mykkumi.domain.repository
 
 interface PreSignedUrlRepository {
-    suspend fun getPreSignedUrl(imageLocalUri: Any): String?
+    suspend fun getPreSignedPostUrl(imageLocalUri: Any): String?
+    suspend fun getPreSignedProfileUrl(imageLocalUri: Any): String?
 }

--- a/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/LoginComposeActivity.kt
+++ b/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/LoginComposeActivity.kt
@@ -209,7 +209,7 @@ class LoginComposeActivity : ComponentActivity() {
                     .background(colorResource(id = com.swmarastro.mykkumi.common_ui.R.color.kakao_background))
                     .pointerInteropFilter {
                         when (it.action) {
-                            MotionEvent.ACTION_DOWN -> handleKakaoLogin()
+                            MotionEvent.ACTION_DOWN -> navController.navigate(route = LoginScreens.LoginSelectHobbyScreen.name)//handleKakaoLogin()
                             else -> false
                         }
                         true

--- a/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/LoginComposeActivity.kt
+++ b/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/LoginComposeActivity.kt
@@ -209,7 +209,7 @@ class LoginComposeActivity : ComponentActivity() {
                     .background(colorResource(id = com.swmarastro.mykkumi.common_ui.R.color.kakao_background))
                     .pointerInteropFilter {
                         when (it.action) {
-                            MotionEvent.ACTION_DOWN -> navController.navigate(route = LoginScreens.LoginSelectHobbyScreen.name)//handleKakaoLogin()
+                            MotionEvent.ACTION_DOWN -> handleKakaoLogin()
                             else -> false
                         }
                         true

--- a/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/onBoarding/LoginInputUserScreen.kt
+++ b/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/onBoarding/LoginInputUserScreen.kt
@@ -301,7 +301,7 @@ fun LoginInputUserScreen(
                     .border(
                         width = 1.dp,
                         color = (
-                                if (viewModel.nickname.value.length < MIN_NICKNAME_LENGTH)
+                                if (viewModel.nickname.value.isEmpty())
                                     colorResource(id = com.swmarastro.mykkumi.common_ui.R.color.neutral_200)
                                 else
                                     colorResource(id = com.swmarastro.mykkumi.common_ui.R.color.neutral_800)

--- a/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/onBoarding/LoginInputUserViewModel.kt
+++ b/feature/auth/src/main/java/com/swmarastro/mykkumi/feature/auth/onBoarding/LoginInputUserViewModel.kt
@@ -95,7 +95,7 @@ class LoginInputUserViewModel @Inject constructor(
             try {
                 var imageUrl: String? = null
                 if(profileImage.value != null)
-                    imageUrl = preSignedUrlRepository.getPreSignedUrl(profileImage.value as Uri)
+                    imageUrl = preSignedUrlRepository.getPreSignedProfileUrl(profileImage.value as Uri)
 
                 val userInfo = UpdateUserInfoRequestVO(
                     nickname = nickname.value,

--- a/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditViewModel.kt
+++ b/feature/post/src/main/java/com/swmarastro/mykkumi/feature/post/PostEditViewModel.kt
@@ -49,7 +49,7 @@ class PostEditViewModel  @Inject constructor(
     fun selectPostImage(uri: Uri) {
         viewModelScope.launch {
             try {
-                val imageUrl = preSignedUrlRepository.getPreSignedUrl(uri)
+                val imageUrl = preSignedUrlRepository.getPreSignedPostUrl(uri)
 
                 if(imageUrl != null) {
                     val addPostImages = _postEditUiState.value


### PR DESCRIPTION
## 구현내용
### 1. pre-signed url 호출하는 API를 프로필, 포스트 이미지 따로
- 프로필 이미지, 포스트 이미지 저장하는 pre-signed url 호출 api를 따로 하기
- why? 저장되는 위치가 다름
